### PR TITLE
Able to define the size of playback logs to ignore

### DIFF
--- a/class/KippoPlayLog.class.php
+++ b/class/KippoPlayLog.class.php
@@ -24,13 +24,17 @@ class KippoPlayLog
     {
         //TODO: ikoniaris
         //This seems to be a very expensive query when run on very big databases (local MySQL hanged and CPU went up to 100%)
-        //SELECT ttylog.session, timestamp, ROUND(LENGTH(ttylog)/1024, 2) AS size FROM ttylog JOIN auth ON ttylog.session=auth.session ORDER BY timestamp DESC;
-        $db_query = "SELECT ttylog.session, timestamp, "
-            . "ROUND(LENGTH(ttylog)/1024, 2) AS size "
-            . "FROM ttylog JOIN auth "
+        //SELECT * FROM ( SELECT ttylog.session, timestamp, ROUND(LENGTH(ttylog)/1024, 2) AS size FROM ttylog JOIN auth ON ttylog.session=auth.session ORDER BY timestamp DESC ) s WHERE size > x;
+        $db_query = "SELECT * "
+            . "FROM ( "
+            . "SELECT ttylog.session, timestamp,  "
+            . "ROUND(LENGTH(ttylog)/1024, 2) AS size  "
+            . "FROM ttylog "
+            . "JOIN auth "
             . "ON ttylog.session=auth.session "
-            . "WHERE LENGTH(ttylog)>85 " //Gets rid of all of the connect then immediate disconnects
-            . "ORDER BY timestamp DESC";
+            . "ORDER BY timestamp DESC "
+            . ") s "
+            . "WHERE size > " . PLAYBACKSIZE_IGNORE;
 
         $result = $this->db_conn->query($db_query);
         //echo 'Found '.$result->num_rows.' records';

--- a/config.php
+++ b/config.php
@@ -1,4 +1,4 @@
-﻿﻿<?php
+﻿<?php
 #Author: ikoniaris
 #Website: bruteforce.gr/kippo-graph
 
@@ -46,5 +46,11 @@ define('DB_PORT', '3306');
 #feature enabled is your choice and not forced.
 #Change NO to YES if you want to enable it.
 define('UPDATE_CHECK', 'NO');
+
+#The following value determines the minimum size (in kb) of the Kippo log needed to be
+#shown in Kippo-Playlog. Any value below it will be ignored.
+#This is useful to remove any sessions that just join and quit immediately afterwards.
+#The value may need updating based on the length of the MOTD (which is displayed after a successful login).
+define('PLAYBACKSIZE_IGNORE', '0.4');
 
 ?>


### PR DESCRIPTION
Added new config option & removed hardcoded value.
Value may need to be altered, depending on the size of the MOTD shown.
