### PR TITLE
Changed google URLs starting with a hard coded http: to begin with // instead.

### DIFF
--- a/include/qgooglevisualapi/QApikeyGoogleGraph.class.php
+++ b/include/qgooglevisualapi/QApikeyGoogleGraph.class.php
@@ -7,5 +7,5 @@
  */
 class QApikeyGoogleGraph extends QVizualisationGoogleGraph
 {
-    const KEY = "http://maps.google.com/maps?file=api&v=2&key=AIzaSyDEMaaLU6t3XuijBcO484BBhUoluqpnFa4";
+    const KEY = "//maps.google.com/maps?file=api&v=2&key=AIzaSyDEMaaLU6t3XuijBcO484BBhUoluqpnFa4";
 }

--- a/include/qgooglevisualapi/QMagictableGoogleGraph.class.php
+++ b/include/qgooglevisualapi/QMagictableGoogleGraph.class.php
@@ -75,12 +75,12 @@ class QMagictableGoogleGraph extends QVisualizationGoogleGraph
             array(
                 "rel" => "stylesheet",
                 "type" => "text/css",
-                "href" => "http://magic-table.googlecode.com/svn/trunk/magic-table/google_visualisation/example.css"
+                "href" => "//magic-table.googlecode.com/svn/trunk/magic-table/google_visualisation/example.css"
             ),
         "script" => array(
             array(
                 "type" => "text/javascript",
-                "src" => "http://www.google.com/jsapi"
+                "src" => "//www.google.com/jsapi"
             ),
             array(
                 "type" => "text/javascript",
@@ -90,7 +90,7 @@ class QMagictableGoogleGraph extends QVisualizationGoogleGraph
             ),
             array(
                 "type" => "text/javascript",
-                "src" => "http://magic-table.googlecode.com/svn/trunk/magic-table/javascript/magic_table.js"
+                "src" => "//magic-table.googlecode.com/svn/trunk/magic-table/javascript/magic_table.js"
             )
         )
     );
@@ -145,7 +145,7 @@ class QMagictableGoogleGraph extends QVisualizationGoogleGraph
 
     public function getReferenceLink()
     {
-        $link = '<a href="http://magic-table.googlecode.com/svn/trunk/magic-table/google_visualisation/example_1.html" target="_blank">Goto MagicTable Project Home</a>';
+        $link = '<a href="//magic-table.googlecode.com/svn/trunk/magic-table/google_visualisation/example_1.html" target="_blank">Goto MagicTable Project Home</a>';
         return $link;
     }
 

--- a/include/qgooglevisualapi/QMapGoogleGraph.class.php
+++ b/include/qgooglevisualapi/QMapGoogleGraph.class.php
@@ -47,7 +47,7 @@ class QMapGoogleGraph extends QVizualisationGoogleGraph
     protected $packageSetup = array(
         "script" => array(
             "type" => "text/javascript",
-            "src" => "http://maps.google.com/maps/api/js?sensor=false" //QApikeyGoogleGraph::KEY,
+            "src" => "//maps.google.com/maps/api/js?sensor=false" //QApikeyGoogleGraph::KEY,
         )
     );
 

--- a/include/qgooglevisualapi/QMixupGoogleGraph.class.php
+++ b/include/qgooglevisualapi/QMixupGoogleGraph.class.php
@@ -269,7 +269,7 @@ class QMixupGoogleGraph
         if (empty($bCustomPackages)) {
             $apiscript = $scriptlet->addChild('script');
             $apiscript->addAttribute("type", "text/javascript");
-            $apiscript->addAttribute("src", "http://www.google.com/jsapi");
+            $apiscript->addAttribute("src", "//www.google.com/jsapi");
         }
 
         $apisource = $scriptlet->addChild('script', $source);

--- a/include/qgooglevisualapi/QVizualisationGoogleGraph.class.php
+++ b/include/qgooglevisualapi/QVizualisationGoogleGraph.class.php
@@ -30,7 +30,7 @@ class QVizualisationGoogleGraph extends QGoogleGraph
      *
      * @var string
      */
-    private $vizReference = "http://code.google.com/apis/visualization/documentation/gallery/";
+    private $vizReference = "//code.google.com/apis/visualization/documentation/gallery/";
 
     /**
      * holder of context node => name of visualisation type
@@ -124,7 +124,7 @@ class QVizualisationGoogleGraph extends QGoogleGraph
         $api = $this->object["api"];
         $apiscript = $api->addChild('script');
         $apiscript->addAttribute("type", "text/javascript");
-        $apiscript->addAttribute("src", "http://www.google.com/jsapi");
+        $apiscript->addAttribute("src", "//www.google.com/jsapi");
 
         // set base section
         $this->object["base"] = new SimpleXMLElement($xml);

--- a/include/qgooglevisualapi/QWordcloudGoogleGraph.class.php
+++ b/include/qgooglevisualapi/QWordcloudGoogleGraph.class.php
@@ -52,11 +52,11 @@ class QWordcloudGoogleGraph extends QVizualisationGoogleGraph
             array(
                 "rel" => "stylesheet",
                 "type" => "text/css",
-                "href" => "http://visapi-gadgets.googlecode.com/svn/trunk/wordcloud/wc.css"
+                "href" => "//visapi-gadgets.googlecode.com/svn/trunk/wordcloud/wc.css"
             ),
         "script" => array(
             "type" => "text/javascript",
-            "src" => "http://visapi-gadgets.googlecode.com/svn/trunk/wordcloud/wc.js"
+            "src" => "//visapi-gadgets.googlecode.com/svn/trunk/wordcloud/wc.js"
         )
     );
 
@@ -105,7 +105,7 @@ class QWordcloudGoogleGraph extends QVizualisationGoogleGraph
 
     public function getReferenceLink()
     {
-        $link = '<a href="http://visapi-gadgets.googlecode.com/svn/trunk/wordcloud/doc.html" target="_blank">Goto Google Visualization Web API Gallery</a>';
+        $link = '<a href="//visapi-gadgets.googlecode.com/svn/trunk/wordcloud/doc.html" target="_blank">Goto Google Visualization Web API Gallery</a>';
         return $link;
     }
 


### PR DESCRIPTION
This way the protocol is dynamically chosen depending on the protocol of the site (http or https).
See RFC1808 and stackoverflow.com/questions/6785442/browser-support-for-urls-beginning-with-double-slash
Otherwise some browsers (like Chrome) would deny loading the map via http if the site itself uses https.

This should have no effect on existing http sites but fixing the issue with https sites.

By the way: nice project, well done!
