### PR TITLE
Add Cowrie support & session checking

### DIFF
--- a/class/KippoPlayLog.class.php
+++ b/class/KippoPlayLog.class.php
@@ -17,15 +17,27 @@ class KippoPlayLog
 
     public function printLogs()
     {
-        $db_query = "SELECT * FROM (
-            SELECT ttylog.session, timestamp, ROUND(LENGTH(ttylog)/1024, 2) AS size
-            FROM ttylog
-            JOIN auth ON ttylog.session = auth.session
-            WHERE auth.success = 1
-            GROUP BY ttylog.session
-            ORDER BY timestamp DESC
-            ) s
-            WHERE size > " . PLAYBACK_SIZE_IGNORE;
+
+        if (strtoupper(BACK_END_ENGINE) === 'COWRIE') {
+            $db_query = "SELECT * FROM (
+                SELECT ttylog.session, timestamp
+                FROM ttylog
+                JOIN auth ON ttylog.session = auth.session
+                WHERE auth.success = 1
+                GROUP BY ttylog.session
+                ORDER BY timestamp DESC
+                ) s";
+        } else {
+            $db_query = "SELECT * FROM (
+                SELECT ttylog.session, timestamp, ROUND(LENGTH(ttylog)/1024, 2) AS size
+                FROM ttylog
+                JOIN auth ON ttylog.session = auth.session
+                WHERE auth.success = 1
+                GROUP BY ttylog.session
+                ORDER BY timestamp DESC
+                ) s
+                WHERE size > " . PLAYBACK_SIZE_IGNORE;
+        }
 
         $rows = R::getAll($db_query);
 
@@ -38,7 +50,8 @@ class KippoPlayLog
             echo '<tr class="dark">';
             echo '<th>ID</th>';
             echo '<th>Timestamp</th>';
-            echo '<th>Size</th>';
+            if ($row['size'])
+                echo '<th>Size</th>';
             echo '<th>Play the log</th>';
             echo '</tr></thead><tbody>';
 
@@ -47,7 +60,8 @@ class KippoPlayLog
                 echo '<tr class="light word-break">';
                 echo '<td>' . $counter . '</td>';
                 echo '<td>' . $row['timestamp'] . '</td>';
-                echo '<td>' . $row['size'] . 'kb' . '</td>';
+                if ($row['size'])
+                    echo '<td>' . $row['size'] . 'kb' . '</td>';
                 echo '<td><a href="include/play.php?f=' . $row['session'] . '" target="_blank"><img class="icon" src="images/play.ico"/>Play</a></td>';
                 echo '</tr>';
                 $counter++;

--- a/config.php.dist
+++ b/config.php.dist
@@ -71,4 +71,10 @@ define('UPDATE_CHECK', 'NO');
 # The value may need tweaking based on the length of your MOTD (displayed after successful logins).
 define('PLAYBACK_SIZE_IGNORE', '0.4');
 
+# The following value determines which honeypot is being used -- Default: KIPPO
+# Values: COWRIE or KIPPO
+define('BACK_END_ENGINE', 'KIPPO');
+
+# The following value determines which honeypot is being used -- Default: /opt/kippo
+define('BACK_END_PATH', '/opt/kippo');
 ?>

--- a/gallery.php
+++ b/gallery.php
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head profile="http://gmpg.org/xfn/11">
-    <title>Kippo-Graph | Fast Visualisation for your Kippo SSH Honeypot Stats</title>
+    <title>Kippo-Graph | Fast Visualization for your Kippo Based SSH Honeypot</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta http-equiv="imagetoolbar" content="no"/>
     <link rel="stylesheet" href="styles/layout.css" type="text/css"/>
@@ -19,7 +19,7 @@
         <h1><a href="index.php">Kippo-Graph</a></h1>
         <br/>
 
-        <p>Fast Visualization for your Kippo SSH Honeypot Stats</p>
+        <p>Fast Visualization for your Kippo Based SSH Honeypot</p>
     </div>
 </div>
 <!-- ####################################################################################################### -->

--- a/include/play.php
+++ b/include/play.php
@@ -14,7 +14,7 @@
 <div class="wrapper">
     <div id="header">
         <h1><a href="../index.php">Kippo-Graph</a></h1>
-        <br/>
+        <br />
 
         <p>Fast Visualization for your Kippo SSH Honeypot Stats</p>
     </div>
@@ -48,7 +48,7 @@
         <div class="whitebox">
             <!-- ####################################################################################################### -->
             <h2>Kippo TTY log</h2>
-            <hr/>
+            <hr />
             <?php
             # Author: ikoniaris, CCoffie
 
@@ -63,11 +63,23 @@
             $session = preg_replace('/[^-a-zA-Z0-9_]/', '', xss_clean($_GET['f']));
 
             $db_query = "SELECT ttylog, session FROM ttylog WHERE session='$session'";
-
             $rows = R::getAll($db_query);
 
             foreach ($rows as $row) {
-                $log = base64_encode($row['ttylog']);
+                if (strtoupper(BACK_END_ENGINE) === 'COWRIE') {
+                    if (function_exists('shell_exec')) {
+                        $log_path = BACK_END_PATH . "/" . $row['ttylog'];
+
+                        if (file_exists($log_path) && is_readable($log_path))
+                            $log = shell_exec("base64 -w 0 " . $log_path . " 2>&1");
+                        else
+                            $errors .= "Unable to access: " . $log_path . "<br />";
+                    } else {
+                        $errors .= "Missing PHP function, shell_exec<br />";
+                    }
+                } else {
+                    $log = base64_encode($row['ttylog']);
+                }
             }
 
             $db_query = "SELECT ip, starttime FROM sessions WHERE id='$session'";
@@ -79,7 +91,8 @@
                 $starttime = $row['starttime'];
             }
 
-            echo "IP: <b>" . $ip . "</b> on " . str_replace(".000000", "", $starttime) . "<br /><br />";
+            if (!empty($ip) && empty($errors)) {
+                echo "IP: <b>" . $ip . "</b> on " . str_replace(".000000", "", $starttime) . "<br /><br />";
             ?>
 
             <!-- Pass PHP variables to javascript - Please ignore the below section -->
@@ -88,12 +101,12 @@
             </script>
             <script type="text/javascript" src="../scripts/jspl.js"></script>
 
-            <noscript>Please enable Javascript for log playback.<br/><br/></noscript>
+            <noscript>Please enable Javascript for log playback.<br /><br /></noscript>
             <div id="description">Error loading specified log.</div>
-            <br/>
+            <br />
 
             <div id="playlog"></div>
-            <br/><br/>
+            <br /><br />
 
             <h3>Downloaded files:</h3>
             <?php
@@ -145,8 +158,13 @@
 
             R::close();
 
-            ?>
-            <?php
+            } else {    // if (!empty($ip)) {
+                echo "<b>Error locating session</b> (" . $session . ")<br /><br />";
+                if (!empty($errors))
+                    echo $errors . "<br /><br />";
+                echo "<hr /><br />";
+            }
+
             //Additional information about IP address
             if (!empty($ip) && filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
                 if (function_exists('exec')) {
@@ -199,7 +217,7 @@
                 if ($latitude && $longitude) {
                     ?>
 
-                    <br/>Google Map:<br/>
+                    <br />Google Map:<br />
 
                     <div id="map" style="width:100%;height:400px;margin-top:10px;"></div>
 

--- a/include/play.php
+++ b/include/play.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head profile="http://gmpg.org/xfn/11">
-    <title>Kippo-Graph | Fast Visualization for your Kippo SSH Honeypot Stats</title>
+    <title>Kippo-Graph | Fast Visualization for your Kippo Based SSH Honeypot</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta http-equiv="imagetoolbar" content="no"/>
     <link rel="stylesheet" href="../styles/layout.css" type="text/css"/>
@@ -16,7 +16,7 @@
         <h1><a href="../index.php">Kippo-Graph</a></h1>
         <br />
 
-        <p>Fast Visualization for your Kippo SSH Honeypot Stats</p>
+        <p>Fast Visualization for your Kippo Based SSH Honeypot</p>
     </div>
 </div>
 <!-- ####################################################################################################### -->

--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head profile="http://gmpg.org/xfn/11">
-    <title>Kippo-Graph | Fast Visualization for your Kippo SSH Honeypot Stats</title>
+    <title>Kippo-Graph | Fast Visualization for your Kippo Based SSH Honeypot</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta http-equiv="imagetoolbar" content="no"/>
     <link rel="stylesheet" href="styles/layout.css" type="text/css"/>
@@ -13,7 +13,7 @@
         <h1><a href="index.php">Kippo-Graph</a></h1>
         <br/>
 
-        <p>Fast Visualization for your Kippo SSH Honeypot Stats</p>
+        <p>Fast Visualization for your Kippo Based SSH Honeypot</p>
     </div>
 </div>
 <!-- ####################################################################################################### -->

--- a/kippo-geo.php
+++ b/kippo-geo.php
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head profile="http://gmpg.org/xfn/11">
-    <title>Kippo-Graph | Fast Visualization for your Kippo SSH Honeypot Stats</title>
+    <title>Kippo-Graph | Fast Visualization for your Kippo Based SSH Honeypot</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta http-equiv="imagetoolbar" content="no"/>
     <link rel="stylesheet" href="styles/layout.css" type="text/css"/>
@@ -13,7 +13,7 @@
         <h1><a href="index.php">Kippo-Graph</a></h1>
         <br/>
 
-        <p>Fast Visualization for your Kippo SSH Honeypot Stats</p>
+        <p>Fast Visualization for your Kippo Based SSH Honeypot</p>
     </div>
 </div>
 <!-- ####################################################################################################### -->

--- a/kippo-graph.php
+++ b/kippo-graph.php
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head profile="http://gmpg.org/xfn/11">
-    <title>Kippo-Graph | Fast Visualization for your Kippo SSH Honeypot Stats</title>
+    <title>Kippo-Graph | Fast Visualization for your Kippo Based SSH Honeypot</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta http-equiv="imagetoolbar" content="no"/>
     <link rel="stylesheet" href="styles/layout.css" type="text/css"/>
@@ -13,7 +13,7 @@
         <h1><a href="index.php">Kippo-Graph</a></h1>
         <br/>
 
-        <p>Fast Visualization for your Kippo SSH Honeypot Stats</p>
+        <p>Fast Visualization for your Kippo Based SSH Honeypot</p>
     </div>
 </div>
 <!-- ####################################################################################################### -->

--- a/kippo-input.php
+++ b/kippo-input.php
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head profile="http://gmpg.org/xfn/11">
-    <title>Kippo-Graph | Fast Visualization for your Kippo SSH Honeypot Stats</title>
+    <title>Kippo-Graph | Fast Visualization for your Kippo Based SSH Honeypot</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta http-equiv="imagetoolbar" content="no"/>
     <link rel="stylesheet" href="styles/layout.css" type="text/css"/>
@@ -13,7 +13,7 @@
         <h1><a href="index.php">Kippo-Graph</a></h1>
         <br/>
 
-        <p>Fast Visualization for your Kippo SSH Honeypot Stats</p>
+        <p>Fast Visualization for your Kippo Based SSH Honeypot</p>
     </div>
 </div>
 <!-- ####################################################################################################### -->

--- a/kippo-ip.php
+++ b/kippo-ip.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head profile="http://gmpg.org/xfn/11">
-    <title>Kippo-Graph | Fast Visualization for your Kippo SSH Honeypot Stats</title>
+    <title>Kippo-Graph | Fast Visualization for your Kippo Based SSH Honeypot</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta http-equiv="imagetoolbar" content="no"/>
     <link rel="stylesheet" href="styles/layout.css" type="text/css"/>
@@ -16,7 +16,7 @@
         <h1><a href="index.php">Kippo-Graph</a></h1>
         <br/>
 
-        <p>Fast Visualization for your Kippo SSH Honeypot Stats</p>
+        <p>Fast Visualization for your Kippo Based SSH Honeypot</p>
     </div>
 </div>
 <!-- ####################################################################################################### -->

--- a/kippo-playlog.php
+++ b/kippo-playlog.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head profile="http://gmpg.org/xfn/11">
-    <title>Kippo-Graph | Fast Visualization for your Kippo SSH Honeypot Stats</title>
+    <title>Kippo-Graph | Fast Visualization for your Kippo Based SSH Honeypot</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta http-equiv="imagetoolbar" content="no"/>
     <link rel="stylesheet" href="styles/layout.css" type="text/css"/>
@@ -15,7 +15,7 @@
         <h1><a href="index.php">Kippo-Graph</a></h1>
         <br/>
 
-        <p>Fast Visualization for your Kippo SSH Honeypot Stats</p>
+        <p>Fast Visualization for your Kippo Based SSH Honeypot</p>
     </div>
 </div>
 <!-- ####################################################################################################### -->


### PR DESCRIPTION
I know it is **kippo**-graph (and not cowrie-graph). However, this makes cowrie once again work with kippo-graph.

In commit: https://github.com/micheloosterhof/cowrie/commit/2248a1ced3eace912f5ac8601c63b0a78d76f90c cowrie does not store the output inside the database (how kippo was doing it), just a file path.

```
mysql> SELECT ttylog, session FROM ttylog LIMIT 5;
+-----------------------------------------+----------+
| ttylog                                  | session  |
+-----------------------------------------+----------+
| log/tty/20151212-233952-77fdd4b8-0i.log | 77fdd4b8 |
| log/tty/20151213-201729-98df99a4-0i.log | 98df99a4 |
| log/tty/20151213-201735-98df99a4-1e.log | 98df99a4 |
| log/tty/20151213-201735-98df99a4-2i.log | 98df99a4 |
| log/tty/20151213-201740-98df99a4-3e.log | 98df99a4 |
+-----------------------------------------+----------+
```

Therefore the wrong base64 values was being sent to the javascript to display on screen.
Instead, kippo-graph now reads the file in (if in cowrie mode).


**Cowrie is a fork of kippo, is is being actively developed (and has been for some time). Kippo also points to this fork as it is no longer getting any updates.**

- - -

During it, I noticed it trying to execute a invalid session ID, so I've made it more visible to an end user when there is a mistake.